### PR TITLE
fix/540/Fetch_Docents_Degree

### DIFF
--- a/src/pages/Professor/EditProfessorPage.tsx
+++ b/src/pages/Professor/EditProfessorPage.tsx
@@ -29,7 +29,11 @@ const validationSchema = Yup.object({
   phone: Yup.string()
     .matches(PHONE_REGEX, PHONE_ERROR_MESSAGE)
     .required("El número de teléfono es obligatorio"),
-  code: Yup.number().optional(),
+  degree: Yup.string().required("El título académico es obligatorio"),
+  code: Yup.number()
+    .typeError("El código debe ser numérico")
+    .required("El código de docente es obligatorio"),
+  
 });
 
 const EditProfessorPage = () => {


### PR DESCRIPTION
## Cambios realizados

1. **Campo `degree`**  
   - Se añade la validación para el título académico, haciéndolo obligatorio.
2. **Campo `code`**  
   - Ahora el código de docente es obligatorio y debe ser numérico.  
   - Se ha añadido un mensaje de error para el caso en que no sea un número.

## Cambios realizados

```ts
degree: Yup.string().required("El título académico es obligatorio"),
code: Yup.number()
    .typeError("El código debe ser numérico")
    .required("El código de docente es obligatorio"),
```